### PR TITLE
Feature Proposal: Using shortcode to display domain-based content

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 ## Support SLA and Next releases
 
-TL;DR - This plugin is not under active development anymore. New issues and support requests won't be addressed.
-
-Read the details here: https://github.com/straube/multiple-domain/issues/82
+**MULTIPLE DOMAIN IS NOW BEING MAINTAINED BY [goINPUT](https://goinput.de/). THE SOURCE CODE NOW LIVES IN WORDPRESS' SUBVERSION. MORE DETAILS CAN BE FOUND ON THE [OFFICIAL PLUGIN PAGE](https://wordpress.org/plugins/multiple-domain/).**
 
 ## About
 

--- a/multiple-domain/MultipleDomain.php
+++ b/multiple-domain/MultipleDomain.php
@@ -272,6 +272,7 @@ class MultipleDomain
     private function hookShortcodes()
     {
         add_shortcode('multiple_domain', [ $this, 'shortcode' ]);
+        add_shortcode('multiple_domain_show_content', [ $this, 'shortcodeShowContent' ]);
     }
 
     //
@@ -684,6 +685,27 @@ class MultipleDomain
     public function shortcode()
     {
         return $this->domain;
+    }
+
+    /**
+     * This shortcode show content if current domain matched with domain attribute.
+     *
+     * @return string The $content if domain matched.
+     * @since  1.0.6
+     */
+    public function shortcodeShowContent($atts, $content)
+    {
+        $default_atts = array(
+            'domain' => ''
+        );
+
+        $params = shortcode_atts( $default_atts, $atts );
+
+        if( $params['domain'] == $this->domain ) {
+            return $content;
+        }
+
+        return '';
     }
 
     /**


### PR DESCRIPTION
Hi, this  is my first time attempt for open-source contribution. I'm aware that this plugin has provide an action hook or a constant to be used in theme but that was developer-friendly only. For this PR, I'm proposing to create additional shortcode that is admin-friendly which can be used in post/pages/widget. The new shortcode and how it works as below. Thanks.

Shortcode:
`[multiple_domain_show_content domain="saved-domain-in-settings.com"]`

How it works:
```
[multiple_domain_show_content domain="my-domain.com"]
    This is content for my-domain.com
[/multiple_domain_show_content]

[multiple_domain_show_content domain="my-domain.io"]
    This is content for my-domain.io
[/multiple_domain_show_content]
```

PS - Sorry for not opening an issue first, I've been using this shortcode recently in my WP and think this is a great addition to the plugin and others.